### PR TITLE
fix warnings when building over git

### DIFF
--- a/examples/module/Cargo.toml
+++ b/examples/module/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2018"
 [lib]
 crate-type = ["cdylib"]
 
-[workspace]
-
 [features]
 lua54 = ["mlua/lua54"]
 lua53 = ["mlua/lua53"]


### PR DESCRIPTION
The workspace tag was added to a package used in examples that causes warnings when building from the git repository in dependencies.