### PR TITLE
Build errors, warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ vendored = ["lua-src", "luajit-src"]
 module = ["mlua_derive"]
 async = ["futures-core", "futures-task", "futures-util"]
 send = []
-serialize = ["serde", "erased-serde"]
+serialize = ["serde", "serde/derive", "erased-serde"]
 macros = ["mlua_derive/macros"]
 alloc_panic = []
 

--- a/examples/module/Cargo.toml
+++ b/examples/module/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
-name = "rust_module"
+name = "example_rust_module"
 version = "0.0.0"
 authors = ["Aleksandr Orlenko <zxteam@pm.me>"]
 edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+
+[workspace]
 
 [features]
 lua54 = ["mlua/lua54"]


### PR DESCRIPTION
The wrong change was merged to fix a warning, this change corrects that and also resolves an issue where serde derive wasn't called out explicitely as a dependency.